### PR TITLE
Updated broken git clone link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In order to run **Adminator** on your local machine all what you need to do is t
 Start by typing the following commands in your terminal in order to get **Adminator** full package on your machine and starting a local development server with live reload feature.
 
 ```
-> git clone https://github.com:puikinsh/Adminator-admin-dashboard.git
+> git clone https://github.com/puikinsh/Adminator-admin-dashboard.git
 > cd adminator
 > npm install
 > npm run dev


### PR DESCRIPTION
Fixed a typo error due to which the following error was coming

`fatal: unable to access 'https://github.com:puikinsh/Adminator-admin-dashboard.git/': Illegal port number`