### PR TITLE
fix: use relative path for scss import

### DIFF
--- a/src/assets/scripts/index.js
+++ b/src/assets/scripts/index.js
@@ -1,4 +1,4 @@
-import 'assets/styles/index.scss';
+import '../styles/index.scss';
 
 import './masonry';
 import './charts';


### PR DESCRIPTION
Awesome work! When installing this project in my CMS I found an issue that made it impossible to use this project from a git submodule.

This commit makes it possible to import this project in other projects. After this change it is possible to use this project as a git submodule or eventually install from npm and just connect with an existing app.

The way it was before, it would look for the scss file in the wrong directory (starts looking at the root of ptoject that is including this package)

This way, it always knows where to find the scss file and thus this package can be imported in other packages/projects.