### PR TITLE
Push dashboard plugin only in dev enviroment

### DIFF
--- a/webpack/plugins/index.js
+++ b/webpack/plugins/index.js
@@ -8,10 +8,12 @@ plugins.push(
   ...(require('./htmlPlugin')),
   ...(require('./internal')),
   require('./caseSensitivePlugin'),
-  require('./dashboardPlugin'),
   require('./extractPlugin')
 );
 
+if (manifest.IS_DEVELOPMENT) {
+  plugins.push(require('./dashboardPlugin'));
+}
 
 if (manifest.IS_PRODUCTION) {
   plugins.push(require('./copyPlugin'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Fixed tickets |  #38 #15 #21 #7 #6
| License       | MIT

Webpack-dashboard is a CLI dashboard for webpack dev server and should not be used in production.  Furthermore it blocks command ```npm run build``` to exit successfully - there were a lot of misunderstandings.

This PR push this plugin only on dev environment.
