### PR TITLE
Upgrade to stable BS4, Fix webpack output dir, Migrate to babel-preset-env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,9 @@
     "transform-object-rest-spread"
   ],
   "presets": [
-    ["es2015", { "modules": false }],
+    ["env", {
+      "modules": false
+    }],
     "stage-0"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "babel-polyfill": "^6.26.0",
-    "bootstrap": "4.0.0-beta.2",
+    "bootstrap": "^4.0.0",
     "bootstrap-datepicker": "^1.7.1",
     "chart.js": "^2.7.1",
     "datatables": "^1.10.13",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-env": "1.6.1",
     "babel-preset-stage-0": "^6.24.1",
     "babel-runtime": "^6.26.0",
     "case-sensitive-paths-webpack-plugin": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-env": "1.6.1",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-stage-0": "^6.24.1",
     "babel-runtime": "^6.26.0",
     "case-sensitive-paths-webpack-plugin": "^2.1.1",

--- a/src/assets/scripts/datatable/index.js
+++ b/src/assets/scripts/datatable/index.js
@@ -3,4 +3,4 @@ import 'datatables';
 
 export default (function () {
   $('#dataTable').DataTable();
-}())
+}());

--- a/webpack/config.js
+++ b/webpack/config.js
@@ -56,7 +56,7 @@ module.exports = {
   entry,
   output: {
     path: manifest.paths.build,
-    publicPath: '/',
+    publicPath: '',
     filename: manifest.outputFiles.bundle,
   },
   module: {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Build?     | ok
| BC break?       | no
| Fixed tickets |  #36 #41
| License       | MIT


This PR:

- [x] Migrates this project to stable BS4.
- Proof of concept - Adminator with BS4 has been deployed as static app here http://adminator-bootstrap4.surge.sh.
- [x] Migrates this project from ```babel-preset-es2015``` to ```babel-preset-env```.
- By default ```babel-preset-env``` has the same behavior as previous presets to compile ES2015 + to ES. It removes also warning when ```npm install```. More: https://babeljs.io/env/.
- [x] Fix webpack output path to load assets files properly when running files from the build directory.
- [x] Add missing semicolon;

Please review and merge @puikinsh @AndreiCN 