### PR TITLE
Display none when spinner inactive

### DIFF
--- a/src/assets/styles/spec/components/loader.scss
+++ b/src/assets/styles/spec/components/loader.scss
@@ -1,12 +1,12 @@
 #loader {
   transition: all 0.3s ease-in-out;
   opacity: 1;
-  visibility: visible;
+  display: default;
 }
 
 #loader.fadeOut {
   opacity: 0;
-  visibility: hidden;
+  display: none;
 }
 
 


### PR DESCRIPTION
## Question and answer

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | Yes
| BC breaks?    | no
| Build  | ok
| Fixed tickets | #65  
| License       | MIT

## Pull request

This pull request change the way of hiding a spinner. When spinner is only hidden unnecessary CPU usage occurs. This implementation uses display: none to care about usage of CPU.

See #65 

## Test
http://adminator-bootstrap4-65.surge.sh/ui.html