### PR TITLE
loader fix for IE11 support

### DIFF
--- a/src/basic-table.html
+++ b/src/basic-table.html
@@ -77,9 +77,9 @@
     </div>
 
     <script>
-      window.addEventListener('load', () => {
+      window.addEventListener('load', function load() {
         const loader = document.getElementById('loader');
-        setTimeout(() => {
+        setTimeout(function() {
           loader.classList.add('fadeOut');
         }, 300);
       });

--- a/src/blank.html
+++ b/src/blank.html
@@ -77,10 +77,10 @@
     </div>
 
     <script>
-      window.addEventListener('load', () => {
+      window.addEventListener('load', function load() {
         const loader = document.getElementById('loader');
-        setTimeout(() => {
-          loader.classList.add('fadeOut');
+        setTimeout(function() {
+            loader.classList.add('fadeOut');
         }, 300);
       });
     </script>

--- a/src/buttons.html
+++ b/src/buttons.html
@@ -27,9 +27,9 @@
     </div>
 
     <script>
-      window.addEventListener('load', () => {
+      window.addEventListener('load', function load() {
         const loader = document.getElementById('loader');
-        setTimeout(() => {
+        setTimeout(function() {
           loader.classList.add('fadeOut');
         }, 3000);
       });

--- a/src/calendar.html
+++ b/src/calendar.html
@@ -77,9 +77,9 @@
     </div>
 
     <script>
-      window.addEventListener('load', () => {
+      window.addEventListener('load', function load() {
         const loader = document.getElementById('loader');
-        setTimeout(() => {
+        setTimeout(function() {
           loader.classList.add('fadeOut');
         }, 300);
       });

--- a/src/charts.html
+++ b/src/charts.html
@@ -77,9 +77,9 @@
     </div>
 
     <script>
-      window.addEventListener('load', () => {
+      window.addEventListener('load', function load() {
         const loader = document.getElementById('loader');
-        setTimeout(() => {
+        setTimeout(function() {
           loader.classList.add('fadeOut');
         }, 300);
       });

--- a/src/chat.html
+++ b/src/chat.html
@@ -77,9 +77,9 @@
     </div>
 
     <script>
-      window.addEventListener('load', () => {
+      window.addEventListener('load', function load() {
         const loader = document.getElementById('loader');
-        setTimeout(() => {
+        setTimeout(function() {
           loader.classList.add('fadeOut');
         }, 300);
       });

--- a/src/compose.html
+++ b/src/compose.html
@@ -77,9 +77,9 @@
     </div>
 
     <script>
-      window.addEventListener('load', () => {
+      window.addEventListener('load', function load() {
         const loader = document.getElementById('loader');
-        setTimeout(() => {
+        setTimeout(function() {
           loader.classList.add('fadeOut');
         }, 300);
       });

--- a/src/datatable.html
+++ b/src/datatable.html
@@ -77,9 +77,9 @@
     </div>
 
     <script>
-      window.addEventListener('load', () => {
+      window.addEventListener('load', function load() {
         const loader = document.getElementById('loader');
-        setTimeout(() => {
+        setTimeout(function() {
           loader.classList.add('fadeOut');
         }, 300);
       });

--- a/src/email.html
+++ b/src/email.html
@@ -77,9 +77,9 @@
     </div>
 
     <script>
-      window.addEventListener('load', () => {
+      window.addEventListener('load', function load() {
         const loader = document.getElementById('loader');
-        setTimeout(() => {
+        setTimeout(function() {
           loader.classList.add('fadeOut');
         }, 300);
       });

--- a/src/forms.html
+++ b/src/forms.html
@@ -77,9 +77,9 @@
     </div>
 
     <script>
-      window.addEventListener('load', () => {
+      window.addEventListener('load', function load() {
         const loader = document.getElementById('loader');
-        setTimeout(() => {
+        setTimeout(function() {
           loader.classList.add('fadeOut');
         }, 300);
       });

--- a/src/google-maps.html
+++ b/src/google-maps.html
@@ -77,9 +77,9 @@
     </div>
 
     <script>
-      window.addEventListener('load', () => {
+      window.addEventListener('load', function load() {
         const loader = document.getElementById('loader');
-        setTimeout(() => {
+        setTimeout(function() {
           loader.classList.add('fadeOut');
         }, 300);
       });

--- a/src/index.html
+++ b/src/index.html
@@ -76,9 +76,9 @@
     </div>
 
     <script>
-      window.addEventListener('load', () => {
+      window.addEventListener('load', function load() {
         const loader = document.getElementById('loader');
-        setTimeout(() => {
+        setTimeout(function() {
           loader.classList.add('fadeOut');
         }, 300);
       });

--- a/src/signin.html
+++ b/src/signin.html
@@ -59,9 +59,9 @@
     </div>
 
     <script>
-      window.addEventListener('load', () => {
+      window.addEventListener('load', function load() {
         const loader = document.getElementById('loader');
-        setTimeout(() => {
+        setTimeout(function() {
           loader.classList.add('fadeOut');
         }, 300);
       });

--- a/src/signup.html
+++ b/src/signup.html
@@ -59,9 +59,9 @@
     </div>
 
     <script>
-      window.addEventListener('load', () => {
+      window.addEventListener('load', function load() {
         const loader = document.getElementById('loader');
-        setTimeout(() => {
+        setTimeout(function() {
           loader.classList.add('fadeOut');
         }, 300);
       });

--- a/src/ui.html
+++ b/src/ui.html
@@ -77,9 +77,9 @@
     </div>
 
     <script>
-      window.addEventListener('load', () => {
+      window.addEventListener('load', function load() {
         const loader = document.getElementById('loader');
-        setTimeout(() => {
+        setTimeout(function() {
           loader.classList.add('fadeOut');
         }, 300);
       });

--- a/src/vector-maps.html
+++ b/src/vector-maps.html
@@ -77,9 +77,9 @@
     </div>
 
     <script>
-      window.addEventListener('load', () => {
+      window.addEventListener('load', function load() {
         const loader = document.getElementById('loader');
-        setTimeout(() => {
+        setTimeout(function() {
           loader.classList.add('fadeOut');
         }, 300);
       });


### PR DESCRIPTION
The little JS snippet for the loader does not work on the latest IE. I changed it to enable IE11 support. Some of the styles may need adjustments, but at least it starts up on IE11 now (has been stuck on the blinking loading icon before). 