### PR TITLE
Fix #127

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "babel-polyfill": "^6.26.0",
     "bootstrap": "^4.0.0",
     "bootstrap-datepicker": "^1.7.1",
+    "brand-colors": "^2.0.1",
     "chart.js": "^2.7.1",
     "datatables": "^1.10.13",
     "easy-pie-chart": "^2.1.7",

--- a/src/assets/styles/spec/settings/index.scss
+++ b/src/assets/styles/spec/settings/index.scss
@@ -1,6 +1,6 @@
 @import 'breakpoints';
 @import 'fonts';
-@import 'brandColors';
+@import '~brand-colors/dist/latest/scss/brand-colors.latest.scss';
 @import 'materialColors';
 @import 'baseColors';
 @import 'borders';


### PR DESCRIPTION
This pull request:
- add brand-colors as dependency (https://github.com/reimertz/brand-colors),
- fix #127.

Build result:
http://grateful-ear.surge.sh

The static file ```brandColor.scss``` file is not referenced in any place beside the import file and as a dependency should be installed via package manager.