### PR TITLE
Fixes dart sass 2.0.0 deprecation warnings

### DIFF
--- a/src/assets/styles/spec/settings/materialColors.scss
+++ b/src/assets/styles/spec/settings/materialColors.scss
@@ -547,4 +547,4 @@ $md-colors: (
   blue-grey-700         : #455a64,
   blue-grey-800         : #37474f,
   blue-grey-900         : #263238,
-) !global;
+);

--- a/src/assets/styles/spec/utils/colors.scss
+++ b/src/assets/styles/spec/utils/colors.scss
@@ -10,11 +10,11 @@
 // ---------------------------------------------------------
 
 @each $item, $color in $md-colors {
-  .c-#{$item},     .cH-#{$item}:hover      { color: $color !important; }
-  .bgc-#{$item},   .bgcH-#{$item}:hover    { background-color: $color !important; }
-  .bdc-#{$item},   .bdcH-#{$item}:hover    { border-color: $color !important; }
-  .fill-#{$item},  .fillH-#{$item}:hover   { fill: $color !important; }
-  .str-#{$item},   .strH-#{$item}:hover    { stroke: $color !important; }
+  .c-#{"" + $item},     .cH-#{"" + $item}:hover      { color: $color !important; }
+  .bgc-#{"" + $item},   .bgcH-#{"" + $item}:hover    { background-color: $color !important; }
+  .bdc-#{"" + $item},   .bdcH-#{"" + $item}:hover    { border-color: $color !important; }
+  .fill-#{"" + $item},  .fillH-#{"" + $item}:hover   { fill: $color !important; }
+  .str-#{"" + $item},   .strH-#{"" + $item}:hover    { stroke: $color !important; }
 }
 
 // ---------------------------------------------------------
@@ -22,9 +22,9 @@
 // ---------------------------------------------------------
 
 @each $item, $color in $grey-colors-alt {
-  .c-#{$item},     .cH-#{$item}:hover      { color: $color !important; }
-  .bgc-#{$item},   .bgcH-#{$item}:hover    { background-color: $color !important; }
-  .bdc-#{$item},   .bdcH-#{$item}:hover    { border-color: $color !important; }
-  .fill-#{$item},  .fillH-#{$item}:hover   { fill: $color !important; }
-  .str-#{$item},   .strH-#{$item}:hover    { stroke: $color !important; }
+  .c-#{"" + $item},     .cH-#{"" + $item}:hover      { color: $color !important; }
+  .bgc-#{"" + $item},   .bgcH-#{"" + $item}:hover    { background-color: $color !important; }
+  .bdc-#{"" + $item},   .bdcH-#{"" + $item}:hover    { border-color: $color !important; }
+  .fill-#{"" + $item},  .fillH-#{"" + $item}:hover   { fill: $color !important; }
+  .str-#{"" + $item},   .strH-#{"" + $item}:hover    { stroke: $color !important; }
 }


### PR DESCRIPTION
Original version has a couple of deprecation warnings from sass (v1.32.5) package:

> DEPRECATION WARNING: As of Dart Sass 2.0.0, !global assignments won't be able to
> declare new variables. Since this assignment is at the root of the stylesheet,
> the !global flag is unnecessary and can safely be removed.

> WARNING: You probably don't mean to use the color value white in interpolation here.
> It may end up represented as white, which will likely produce invalid CSS.
> Always quote color names when using them as strings or map keys (for example, "white").
> If you really want to use the color value here, use '"" + $item'.

This PR fixes the problem.
